### PR TITLE
feat: Support multiple monitors

### DIFF
--- a/LiveDraw/MainWindow.xaml
+++ b/LiveDraw/MainWindow.xaml
@@ -6,7 +6,7 @@
     xmlns:local="clr-namespace:AntFu7.LiveDraw"
     x:Class="AntFu7.LiveDraw.MainWindow"
     xmlns:sys="clr-namespace:System;assembly=mscorlib"
-    mc:Ignorable="d" ResizeMode="NoResize" UseLayoutRounding="True" WindowStartupLocation="CenterScreen" WindowState="Maximized" Background="{StaticResource FakeTransparent}" AllowsTransparency="True" WindowStyle="None" Title="LiveDraw Dev" Icon="Rescoures/icon.ico" KeyDown="Window_KeyDown" >
+    mc:Ignorable="d" ResizeMode="NoResize" UseLayoutRounding="True" WindowStartupLocation="Manual" Background="{StaticResource FakeTransparent}" AllowsTransparency="True" WindowStyle="None" Title="LiveDraw Dev" Icon="Rescoures/icon.ico" KeyDown="Window_KeyDown" Loaded="MainWindow_Loaded" >
     <Window.Resources>
         <SolidColorBrush x:Key="PaintingColor1" Color="#FF86E238"/>
         <SolidColorBrush x:Key="PaintingColor2" Color="#FF38E2A8"/>

--- a/LiveDraw/MainWindow.xaml.cs
+++ b/LiveDraw/MainWindow.xaml.cs
@@ -16,6 +16,7 @@ using System.Windows.Media.Imaging;
 using System.Windows.Threading;
 using Brush = System.Windows.Media.Brush;
 using Point = System.Windows.Point;
+using Screen = System.Windows.Forms.Screen;
 
 namespace AntFu7.LiveDraw
 {
@@ -97,6 +98,13 @@ namespace AntFu7.LiveDraw
                 Application.Current.Shutdown(0);
             }
         }
+
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "<Pending>")]
+		private void MainWindow_Loaded(object sender, RoutedEventArgs e)
+		{
+			AdjustWindowSize();
+			Microsoft.Win32.SystemEvents.DisplaySettingsChanged += (_, _) => AdjustWindowSize();
+		}
 
         private void Exit(object sender, EventArgs e)
         {
@@ -408,6 +416,22 @@ namespace AntFu7.LiveDraw
                 EraseByPoint_Flag = (int)erase_mode.NONE;
             }
         }
+
+		private void AdjustWindowSize()
+		{
+			var primaryArea = Screen.PrimaryScreen.WorkingArea;
+			var scaleRatio = Math.Max(
+				primaryArea.Width / SystemParameters.PrimaryScreenWidth,
+				primaryArea.Height / SystemParameters.PrimaryScreenHeight
+			);
+			Left = Screen.AllScreens.Min(s => s.WorkingArea.Left) / scaleRatio;
+			Top = Screen.AllScreens.Min(s => s.WorkingArea.Top) / scaleRatio;
+			Width = Screen.AllScreens.Max(s => s.WorkingArea.Right) / scaleRatio - Left;
+			Height = Screen.AllScreens.Max(s => s.WorkingArea.Bottom) / scaleRatio - Top;
+
+			Canvas.SetTop(Palette, (primaryArea.Top + primaryArea.Height / 2) / scaleRatio - Top - Palette.ActualHeight / 2);
+			Canvas.SetLeft(Palette, (primaryArea.Left + primaryArea.Width / 2) / scaleRatio - Left - Palette.ActualWidth / 2);
+		}
         #endregion
 
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Live-Draw currently only works for the primary monitor. You cannot draw on additional screens. This PR solves this problem. The approach is to set the bounding of the window to cover all monitors at the beginning. To make sure the palette will always be in visible areas, it'll be placed in the center of the primary screen during this process. Additionally, since the screen settings may change, this process will also be executed again when it happens (triggered by `Microsoft.Win32.SystemEvents.DisplaySettingsChanged`).  
I personally have 2 screens, and it works fine on my computer. I suppose it'll also work for more than 2 monitors.
